### PR TITLE
fix: update semantic release pipeline configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,14 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      issues: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -96,17 +99,22 @@ jobs:
     
     - name: Python Semantic Release
       id: semantic-release
-      uses: python-semantic-release/python-semantic-release@v9.1.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Publish release to GitHub
-      if: steps.semantic-release.outputs.released == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "Released version ${{ steps.semantic-release.outputs.version }}"
-        gh release create v${{ steps.semantic-release.outputs.version }} \
-          --title "v${{ steps.semantic-release.outputs.version }}" \
-          --notes "${{ steps.semantic-release.outputs.release_notes }}" \
-          dist/*
+        git config --global user.name "semantic-release"
+        git config --global user.email "semantic-release@users.noreply.github.com"
+        # Debug information
+        echo "Current git status:"
+        git status
+        echo "Current branch:"
+        git branch
+        # Run semantic release with verbose output
+        poetry run semantic-release --verbose version
+        # Only publish if version command succeeded
+        if [ $? -eq 0 ]; then
+          poetry run semantic-release --verbose publish
+        else
+          echo "Version command failed, skipping publish"
+          exit 1
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,18 @@ changelog_file = "CHANGELOG.md"
 build_command = "poetry build"
 dist_path = "dist/"
 upload_to_pypi = false
-upload_to_repository = false
 upload_to_release = true
 commit_message = "chore(release): {version} [skip ci]"
 commit_author = "semantic-release <semantic-release@users.noreply.github.com>"
 major_on_zero = false
 tag_format = "v{version}"
+
+[tool.semantic_release.remote.token]
+env = "GH_TOKEN"
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- Fix semantic-release configuration in CI pipeline
- Update pyproject.toml with proper semantic-release v9 configuration
- Add additional GitHub permissions for the release job
- Improve error handling and logging during release process
- Fix token configuration

## Test plan
- Merge to main to verify that semantic-release runs successfully
- Check that version is updated and GitHub release is created

This fixes the failing release pipeline seen in: https://github.com/OffendingCommit/commit-bingo/actions/runs/13635615212/job/38113565888

🤖 Generated with [Claude Code](https://claude.ai/code)